### PR TITLE
Retry ssh commands on runtime exceptions

### DIFF
--- a/src/pallet/ssh/execute.clj
+++ b/src/pallet/ssh/execute.clj
@@ -85,7 +85,8 @@
     (if (or (and (= type :clj-ssh/open-channel-failure)
                  (= reason :clj-ssh/channel-open-failed))
             (= type :runtime-exception)
-            (= type :remote-execution-failure))
+            (= type :remote-execution-failure)
+            (= (class e) com.jcraft.jsch.JSchException))
       {::retriable true ::exception e}
       (throw e))
     (throw e)))

--- a/src/pallet/ssh/execute.clj
+++ b/src/pallet/ssh/execute.clj
@@ -85,11 +85,12 @@
     (if (or (and (= type :clj-ssh/open-channel-failure)
                  (= reason :clj-ssh/channel-open-failed))
             (= type :runtime-exception)
-            (= type :remote-execution-failure)
-            (= (class e) com.jcraft.jsch.JSchException))
+            (= type :remote-execution-failure))
       {::retriable true ::exception e}
       (throw e))
-    (throw e)))
+    (if (= (class e) com.jcraft.jsch.JSchException)
+      {::retriable true ::exception e}
+      (throw e))))
 
 (defn ^{:internal true} with-connection*
   "Execute a function with a connection to the current target node,"

--- a/src/pallet/ssh/execute.clj
+++ b/src/pallet/ssh/execute.clj
@@ -80,10 +80,12 @@
 
 (defn ^{:internal true} with-connection-exception-handler
   [e]
-  (logging/errorf e "SSH Error")
+  (logging/errorf e "SSH Error %s" (ex-data e))
   (if-let [{:keys [type reason]} (ex-data e)]
-    (if (and (= type :clj-ssh/open-channel-failure)
-             (= reason :clj-ssh/channel-open-failed))
+    (if (or (and (= type :clj-ssh/open-channel-failure)
+                 (= reason :clj-ssh/channel-open-failed))
+            (= type :runtime-exception)
+            (= type :remote-execution-failure))
       {::retriable true ::exception e}
       (throw e))
     (throw e)))


### PR DESCRIPTION
This is a cherry pick of 3 commits from the mothership. I don't think this will move the needle in terms of pallet reliability, but should not hurt either. 
I assume `smart-os` is the right branch. Although I am not sure why the version was changed [here](https://github.com/walmartlabs/pallet/commit/9f513502133a23ebda293c960fb3d46a6259e954) as we still use snapshot in deployment-tools. Ping @Moocar, @dbriones
